### PR TITLE
Ensure new user is author of "registered" activity item.

### DIFF
--- a/wp-user-activity/includes/actions/class-action-users.php
+++ b/wp-user-activity/includes/actions/class-action-users.php
@@ -262,6 +262,7 @@ class WP_User_Activity_Type_User extends WP_User_Activity_Type {
 			'object_type' => $this->object_type,
 			'object_name' => $user->user_nicename,
 			'object_id'   => $user->ID,
+			'user_id'     => $user->ID,
 			'action'      => 'create'
 		) );
 	}


### PR DESCRIPTION
When a new user is added manually by a site admin via wp-admin, ensure that the new user, not the currently logged-in user, is the author of the activity item.