### PR TITLE
Move user query inside of user filter if statement.

### DIFF
--- a/wp-user-activity/includes/admin.php
+++ b/wp-user-activity/includes/admin.php
@@ -327,12 +327,6 @@ function wp_user_activity_add_dropdown_filters( $post_type = '' ) {
 		return;
 	}
 
-	// Query for users
-	$users = get_users( array(
-		'count_total' => false,
-		'orderby'     => 'display_name'
-	) );
-
 	// Setup action types
 	$action_types = $GLOBALS['wp_user_activity_actions'];
 
@@ -378,7 +372,14 @@ function wp_user_activity_add_dropdown_filters( $post_type = '' ) {
 	endif;
 
 	// Show the user filter
-	if ( apply_filters( 'wp_user_activity_show_user_filter', true ) ) : ?>
+	if ( apply_filters( 'wp_user_activity_show_user_filter', true ) ) :
+
+	// Query for users
+	$users = get_users( array(
+		'count_total' => false,
+		'orderby'     => 'display_name'
+	) );
+	?>
 
 	<label class="screen-reader-text" for="wp-user-activity-user"><?php esc_html_e( 'Filter by user', 'wp-user-activity' ); ?></label>
 	<select name="wp-user-activity-user" id="wp-user-activity-user">


### PR DESCRIPTION
On large sites, the user query will kill the Activity dashboard page load. As the code is written, the user query is run whether or not it is needed; I've moved it inside the `if ( apply_filters( 'wp_user_activity_show_user_filter', true ) ) :` statement so that filtering that boolean will prevent the query from being run, too.

I thought it'd be nice to use `wp_is_large_network()` but it appears to be unavailable on single site installs.