### PR TITLE
Don't trigger notice when `the_content` is called incorrectly

### DIFF
--- a/wp-user-activity/includes/post-types.php
+++ b/wp-user-activity/includes/post-types.php
@@ -121,6 +121,11 @@ function wp_user_activity_append_action_to_the_content( $content = '' ) {
 	// Get the current post
 	$post = get_post();
 
+	// If `the_content` is called without setting a post context, don't trigger notices.
+	if ( ! $post instanceof \WP_Post ) {
+		return $content;
+	}
+
 	// Bail if not an activity post
 	if ( 'activity' !== $post->post_type ) {
 		return $content;


### PR DESCRIPTION
If a plugin or theme calls `the_content` without setting the `$post` global, a notice is thrown before this function bails due to the ambiguous context.