### PR TITLE
Fix double encoding in filter_plugin_action_links

### DIFF
--- a/wp-user-activity/includes/sponsor.php
+++ b/wp-user-activity/includes/sponsor.php
@@ -37,14 +37,11 @@ add_action( 'admin_init', function() {
  */
 function filter_plugin_action_links( $actions = array() ) {
 
-	// Sponsor text
-	$text = esc_html_x( 'Sponsor', 'verb', 'wp-user-activity' );
-
 	// Sponsor URL
-	$url  = 'https://buy.stripe.com/7sI3cd2tK1Cy2lydQR';
+	$url = 'https://buy.stripe.com/7sI3cd2tK1Cy2lydQR';
 
 	// Merge links & return
 	return array_merge( $actions, array(
-		'sponsor' => '<a href="' . esc_url( $url ) . '">' . esc_html( $text ) . '</a>'
+		'sponsor' => '<a href="' . esc_url( $url ) . '">' . esc_html_x( 'Sponsor', 'verb', 'wp-user-activity' ) . '</a>'
 	) );
 }


### PR DESCRIPTION
There were two `esc_*` function calls.